### PR TITLE
Bump jetty.version in /resource-server

### DIFF
--- a/resource-server/pom.xml
+++ b/resource-server/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.15.v20190215</jetty.version>
+        <jetty.version>9.4.35.v20201120</jetty.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Bumps `jetty.version` from 9.4.15.v20190215 to 9.4.35.v20201120.

Updates `jetty-annotations` from 9.4.15.v20190215 to 9.4.35.v20201120
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.15.v20190215...jetty-9.4.35.v20201120)

Updates `jetty-server` from 9.4.15.v20190215 to 9.4.35.v20201120
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.15.v20190215...jetty-9.4.35.v20201120)

Updates `jetty-webapp` from 9.4.15.v20190215 to 9.4.35.v20201120
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.15.v20190215...jetty-9.4.35.v20201120)

Signed-off-by: dependabot[bot] <support@github.com>